### PR TITLE
feat: Remove magic numbers in actions workflows

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF:17}" >> $GITHUB_ENV # refs/tags/image-v1.0.0 substring starting at 1.0.0
+        # retrieves latest tag name, snips string after first hyphen
+        run: echo "RELEASE_VERSION=${$(git describe --abbrev=0)#*-}" >> $GITHUB_ENV
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry

--- a/.github/workflows/tweeter-automation.yaml
+++ b/.github/workflows/tweeter-automation.yaml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set RELEASE_VERSION ENV var
-        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${$(git describe --abbrev=0)}" >> $GITHUB_ENV
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17.x


### PR DESCRIPTION
Uses:
- `git describe --abbrev=0` to grab the latest version tag.
- Bash string splitting for getting the version from an `image-vX.Y.Z` tag

You can verify the string splitting in your Terminal with:

```
foo="refs/tags/image-v1.0.0"
bar=${foo#*-}
echo $bar # v1.0.0
foo="refs/tags/image-v1.0.0-alpha"
bar=${foo#*-}
echo $bar # v1.0.0-alpha
minor=${$(git describe --abbrev=0)#*.}
echo $minor # 0.0 (if latest tag is v1.0.0)
```